### PR TITLE
add Apple Silicon (MPS) support

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,25 @@ siam-pred -h
    image will be ~10G and cache dir ~ 10G (can be removed after) tmp dir ~32G (but automaticaly deleted )
 
 
+## Apple Silicon (Metal / MPS)
+
+On Apple Silicon (M1–M4) the model can run on the integrated GPU via PyTorch's
+Metal backend. Either request it explicitly:
+
+```bash
+siam-pred -i INPUT_FILENAME -device mps -nbthread 1
+```
+
+or just leave `-device cuda` as-is: when CUDA isn't available, SIAM now falls
+back to MPS automatically (and only to CPU if MPS is also unavailable). A few
+3D ops aren't implemented on Metal yet; `PYTORCH_ENABLE_MPS_FALLBACK=1` is
+set automatically so those transparently run on CPU.
+
+Note that nnU-Net's sliding-window inference moves tiles between device and
+host on non-CUDA backends, so MPS is faster than CPU but not as fast as CUDA.
+On a 48 GB unified-memory machine, use `-nbthread 1` or `2` to avoid OOM
+kills from parallel worker processes.
+
 ## Memory issues
 
 Running with GPU requires more than 12 G on the GPU card

--- a/SIAMpred/entry_point.py
+++ b/SIAMpred/entry_point.py
@@ -51,11 +51,24 @@ def main():
     args = parser.parse_args()
 
     device_arg = args.device
-    if device_arg=='cuda':
+    if device_arg == 'cuda':
         check_mem = test_cuda_memory_greate_than()
         if check_mem is False:
-            print(f'Warning : forcing to cpu')
+            if torch.backends.mps.is_available():
+                print('Falling back to Apple Metal (MPS)')
+                device_arg = 'mps'
+            else:
+                print('Warning : forcing to cpu')
+                device_arg = 'cpu'
+
+    if device_arg == 'mps':
+        if not torch.backends.mps.is_available():
+            print('MPS not available on this system; forcing to cpu')
             device_arg = 'cpu'
+        else:
+            # A handful of 3D ops aren't implemented on Metal yet; let them
+            # transparently fall back to CPU instead of crashing.
+            os.environ.setdefault('PYTORCH_ENABLE_MPS_FALLBACK', '1')
 
     #arrg, not sure how to force nnunet to really use the request nbthread it is still using the env variable
     os.environ['nnUNet_def_n_proc'] = str(args.nbthread)

--- a/SIAMpred/nn_prediction.py
+++ b/SIAMpred/nn_prediction.py
@@ -8,6 +8,37 @@ sys.stdout = sys.__stdout__
 from SIAMpred.paths import get_model_path_and_fold, addprefixtofilenames, get_parent_path, gfile
 import json, re
 import torchio as tio
+from contextlib import contextmanager
+
+
+@contextmanager
+def _filter_stdout(drop_substrings):
+    """Suppress stdout lines containing any of the given substrings."""
+    real = sys.stdout
+
+    class _Filter:
+        def __init__(self):
+            self._buf = ''
+
+        def write(self, s):
+            self._buf += s
+            while '\n' in self._buf:
+                line, self._buf = self._buf.split('\n', 1)
+                if not any(sub in line for sub in drop_substrings):
+                    real.write(line + '\n')
+
+        def flush(self):
+            if self._buf and not any(sub in self._buf for sub in drop_substrings):
+                real.write(self._buf)
+            self._buf = ''
+            real.flush()
+
+    sys.stdout = _Filter()
+    try:
+        yield
+    finally:
+        sys.stdout.flush()
+        sys.stdout = real
 
 def get_nn_predictor(
         use_tta: bool = False,
@@ -15,17 +46,21 @@ def get_nn_predictor(
         verbose: bool = False
 ):
     os.environ['nnUNet_compile'] = 'F'
-    predictor = nnUNetPredictor(
-        tile_step_size=0.5,
-        use_gaussian=True,
-        use_mirroring=use_tta,
-        perform_everything_on_device=True,
-        device=device,
-        verbose=verbose,
-        verbose_preprocessing=verbose
-    )
+    # nnUNet only honours perform_everything_on_device on CUDA, and prints
+    # the same warning unconditionally on non-CUDA devices regardless of the
+    # value we pass. Silence just that one line here.
+    with _filter_stdout(['perform_everything_on_device=True is only supported for cuda']):
+        predictor = nnUNetPredictor(
+            tile_step_size=0.5,
+            use_gaussian=True,
+            use_mirroring=use_tta,
+            perform_everything_on_device=(device.type == 'cuda'),
+            device=device,
+            verbose=verbose,
+            verbose_preprocessing=verbose
+        )
 
-    if device == torch.device('cpu'):
+    if device.type == 'cpu':
         torch.set_num_threads(os.cpu_count())
     return predictor
 


### PR DESCRIPTION
Thanks for this terrific model.

When -device cuda is requested but no CUDA GPU is available, fall back to MPS first (and only to CPU if MPS is also missing). For any MPS run, set PYTORCH_ENABLE_MPS_FALLBACK=1 so the handful of 3D ops Metal still lacks transparently run on CPU instead of crashing.

Also silence nnUNet's misleading "perform_everything_on_device=True is only supported for cuda" warning, which it prints unconditionally on non-CUDA devices regardless of the value passed in.